### PR TITLE
Fix failing task being falsely reported as succeeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Next release
+------------
+
+* Fix failed `rake rspec-rerun:rerun` being falsely reported as success
+
 0.1.1
 -----
 

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -3,8 +3,6 @@ require 'rspec/core/rake_task'
 desc "Run RSpec examples."
 RSpec::Core::RakeTask.new("rspec-rerun:run") do |t|
   t.pattern = "spec/**/*_spec.rb"
-  t.verbose = false
-  t.fail_on_error = false
   t.rspec_opts = [
     "--require", File.join(File.dirname(__FILE__), '../rspec-rerun'),
     "--format", "RSpec::Rerun::Formatters::FailuresFormatter",
@@ -15,8 +13,6 @@ end
 desc "Re-run failed RSpec examples."
 RSpec::Core::RakeTask.new("rspec-rerun:rerun") do |t|
   t.pattern = "spec/**/*_spec.rb"
-  t.verbose = false
-  t.fail_on_error = false
   t.rspec_opts = [
     "-O", RSpec::Rerun::Formatters::FailuresFormatter::FILENAME,
     File.exist?(".rspec") ? File.read(".rspec").split(/\n+/).map { |l| l.shellsplit } : nil
@@ -26,10 +22,13 @@ end
 desc "Run RSpec code examples."
 task "rspec-rerun:spec" do
   FileUtils.rm_f RSpec::Rerun::Formatters::FailuresFormatter::FILENAME
-  Rake::Task["rspec-rerun:run"].execute
-  unless $?.success?
+
+  begin
+    Rake::Task["rspec-rerun:run"].execute
+  rescue
     failed_count = File.read(RSpec::Rerun::Formatters::FailuresFormatter::FILENAME).split(/\n+/).count
     puts "[#{Time.now}] Failed, rerunning #{failed_count} failure(s) ..."
+
     Rake::Task["rspec-rerun:rerun"].execute
   end
 end


### PR DESCRIPTION
Previously the fail_on_error flag was set to false which meant that the
spec task would pass even if the rerun task had failing tests.
