### PR TITLE
Upgrade to RSpec 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-0.2.1 (Next)
+0.3.0 (Next)
 ------------
 
 * Your contribution here.
+* Upgraded to RSpec 3. This version is not compatible with RSpec 2.x anymore.
+
+0.2.1
+-----
 * [#23](https://github.com/dblock/rspec-rerun/issues/23): Fixed dual formatter error - [@KurtPreston](https://github.com/KurtPreston)
 
 0.2.0

--- a/lib/rspec-rerun/formatters/failures_formatter.rb
+++ b/lib/rspec-rerun/formatters/failures_formatter.rb
@@ -1,3 +1,6 @@
+require 'rspec/support'
+require 'rspec/core'
+require 'rspec/legacy_formatters'
 require 'rspec/core/formatters/base_formatter'
 
 module RSpec

--- a/rspec-rerun.gemspec
+++ b/rspec-rerun.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.test_files = s.files.grep(/^(spec)\//)
 
-  s.add_runtime_dependency 'rspec', '>= 2.11.0', '< 3'
+  s.add_runtime_dependency 'rspec', '~> 3.0'
+  s.add_runtime_dependency 'rspec-legacy_formatters'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,9 @@ require 'tmpdir'
     require file
   end
 end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION
Hi dblock,

this is a (non-downward-compatible) PR for RSpec 3 using [rspec-legacy_formatters](https://github.com/rspec/rspec-legacy_formatters)
One could probably maintain RSpec 2 compatibility with some version magic, but I don't know if it's worth the trouble...
Also, here is an example of how to really upgrade formatters to RSpec 3 style:
https://github.com/bsingr/growl-rspec/commit/4a82ff9213b1b85795a5a279b0831d6af76948d1

Hope this is useful :)
  Martin
