### PR TITLE
Fix bug: RSPEC_RERUN_TAG option doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------
 
 * Your contribution here.
+* [#30](https://github.com/dblock/rspec-rerun/pull/30): Fixed RSPEC_RERUN_TAG option issue - [@kinopyo](https://github.com/kinopyo).
 
 0.3.0 (3/10/2015)
 -----------------

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -86,7 +86,7 @@ def parse_args(args)
 
   # Parse environment variables
   opts[:pattern] ||= ENV['RSPEC_RERUN_PATTERN'] if ENV['RSPEC_RERUN_PATTERN']
-  opts[:tag] ||= ENV['RSPEC_RERUN_TAG'] if ENV['RSPEC_RERUN_PATTERN']
+  opts[:tag] ||= ENV['RSPEC_RERUN_TAG'] if ENV['RSPEC_RERUN_TAG']
   opts[:retry_count] ||= ENV['RSPEC_RERUN_RETRY_COUNT'] if ENV['RSPEC_RERUN_RETRY_COUNT']
   opts[:verbose] = (ENV['RSPEC_RERUN_VERBOSE'] != 'false') if opts[:verbose].nil?
 


### PR DESCRIPTION
A simple fix. Sadly the current spec couldn't catch it because [`RSPEC_RERUN_PATTERN` is also set as part of the command](https://github.com/dblock/rspec-rerun/blob/master/spec/rspec-rerun/tasks/rspec_task_spec.rb#L75)