### PR TITLE
remove rspec-legacy_formatters to fix output with rspec-core 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 
 * Your contribution here.
+* [#46](https://github.com/dblock/rspec-rerun/pull/46): remove rspec-legacy_formatters to fix output with rspec-core 3.3 - [@thekendalmiller](https://github.com/thekendalmiller)
 * [#44](https://github.com/dblock/rspec-rerun/pull/44): support RSpec > 3.0 and shared example group - [@thekendalmiller](https://github.com/thekendalmiller)
 
 1.0.0 (5/13/2015)

--- a/lib/rspec-rerun/formatter.rb
+++ b/lib/rspec-rerun/formatter.rb
@@ -1,17 +1,20 @@
 require 'rspec/core'
-require 'rspec/legacy_formatters'
-require 'rspec/core/formatters/base_formatter'
+require 'rspec/core/formatters'
 
 module RSpec
   module Rerun
-    class Formatter < RSpec::Core::Formatters::BaseFormatter
+    class Formatter
+      ::RSpec::Core::Formatters.register self, :dump_failures
+
       FILENAME = 'rspec.failures'
 
-      def dump_failures
-        if failed_examples.empty?
+      def initialize(_); end
+
+      def dump_failures(notification)
+        if notification.failed_examples.empty?
           clean!
         else
-          rerun_commands = failed_examples.map { |e| retry_command(e) }
+          rerun_commands = notification.failed_examples.map { |e| retry_command(e) }
           File.write(FILENAME, rerun_commands.join("\n"))
         end
       end

--- a/rspec-rerun.gemspec
+++ b/rspec-rerun.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files lib README.md`.split($INPUT_RECORD_SEPARATOR)
 
   s.add_runtime_dependency 'rspec', '~> 3.0'
-  s.add_runtime_dependency 'rspec-legacy_formatters'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
No need to have legacy formatters since we no longer support rspec2

Fixes https://github.com/dblock/rspec-rerun/issues/43
