### PR TITLE
docs: retry_count example and how to use in zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Parameters
 
 The `rspec-rerun:spec` task accepts the following parameters:
 
-* `retry_count`: number of retries, defaults to 1, also available by setting
+* `retry_count`: number of retries, defaults to 1
+
+e.g. `rake rspec-rerun:spec[3]`. ZSH users will want to try noglob or quote around the task name: `rake 'rspec-rerun:spec[3]'`.
+
 
 You can set the following global environment variables:
 


### PR DESCRIPTION
prevents this:

bundle exec rake rspec-rerun:spec[3]
`zsh: no matches found: rspec-rerun:spec[3]`